### PR TITLE
updated pinot testContainer to use Auth

### DIFF
--- a/integration-test/container/pinot.go
+++ b/integration-test/container/pinot.go
@@ -119,7 +119,7 @@ func RunPinotContainer(ctx context.Context) (*Pinot, error) {
 }
 
 func (p *Pinot) CreateUser(_ context.Context, userBytes []byte) (*model.UserActionResponse, error) {
-	client := goPinotAPI.NewPinotAPIClient("http://" + p.URI)
+	client := goPinotAPI.NewPinotAPIClient("http://"+p.URI, "YWRtaW46YWRtaW4=")
 
 	userCreationResponse, err := client.CreateUser(userBytes)
 	if err != nil {
@@ -131,7 +131,7 @@ func (p *Pinot) CreateUser(_ context.Context, userBytes []byte) (*model.UserActi
 }
 
 func (p *Pinot) GetUsers(_ context.Context) (*model.GetUsersResponse, error) {
-	client := goPinotAPI.NewPinotAPIClient("http://" + p.URI)
+	client := goPinotAPI.NewPinotAPIClient("http://"+p.URI, "YWRtaW46YWRtaW4=")
 
 	userResp, err := client.GetUsers()
 	if err != nil {

--- a/integration-test/go.mod
+++ b/integration-test/go.mod
@@ -3,7 +3,7 @@ module integration-test
 go 1.22.0
 
 require (
-	github.com/azaurus1/go-pinot-api v0.0.0-20240303134912-973e7ff51e70
+	github.com/azaurus1/go-pinot-api v0.1.1-0.20240306034329-0b8450520d31
 	github.com/google/uuid v1.6.0
 	github.com/hamba/avro/v2 v2.20.0
 	github.com/stretchr/testify v1.9.0

--- a/integration-test/go.sum
+++ b/integration-test/go.sum
@@ -10,10 +10,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=
 github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
-github.com/azaurus1/go-pinot-api v0.0.0-20240303131441-0eaeb79e8758 h1:jmuXzAsFeNOgCQav/53zzpilbmmL297KqxuPRW2N754=
-github.com/azaurus1/go-pinot-api v0.0.0-20240303131441-0eaeb79e8758/go.mod h1:dx4MyVRh5vanEDFLG6xGeDX5uL82mHvp2OeILo69Sbo=
-github.com/azaurus1/go-pinot-api v0.0.0-20240303134912-973e7ff51e70 h1:MceJjw0MzTfPhBX0njOi+xxsBUwK7z4nOvIQT+Y8CFk=
-github.com/azaurus1/go-pinot-api v0.0.0-20240303134912-973e7ff51e70/go.mod h1:dx4MyVRh5vanEDFLG6xGeDX5uL82mHvp2OeILo69Sbo=
+github.com/azaurus1/go-pinot-api v0.1.1-0.20240306034329-0b8450520d31 h1:57obXV5DpleWQjgo5qrrlIq/QrwywD0F8yVEJrb5NOs=
+github.com/azaurus1/go-pinot-api v0.1.1-0.20240306034329-0b8450520d31/go.mod h1:dx4MyVRh5vanEDFLG6xGeDX5uL82mHvp2OeILo69Sbo=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/containerd/containerd v1.7.13 h1:wPYKIeGMN8vaggSKuV1X0wZulpMz4CrgEsZdaCyB6Is=

--- a/integration-test/testdata/pinot-controller.conf
+++ b/integration-test/testdata/pinot-controller.conf
@@ -1,16 +1,3 @@
-# pinot.broker.client.queryPort=8099
-# pinot.broker.routing.table.builder.class=random
-# pinot.set.instance.id.to.hostname=true
-# pinot.broker.access.control.class=org.apache.pinot.broker.broker.BasicAuthAccessControlFactory
-# pinot.broker.access.control.principals=admin,user
-# pinot.broker.access.control.principals.admin.password=admin
-# pinot.broker.access.control.principals.user.password=user
-# controller.access.protocols.http.port=9000
-# controller.segment.fetcher.auth.token=Basic YWRtaW46YWRtaW4=
-# # Replace with your Zookeeper server network alias
-# controller.helix.cluster.name=pinot-cluster
-# controller.port=9000
-
 controller.helix.cluster.name=pinot-cluster
 controller.port=9000
 controller.vip.host=pinot-controller
@@ -18,3 +5,7 @@ controller.vip.port=9000
 controller.data.dir=/var/pinot/controller/data
 controller.zk.str=pinot-zk:2181
 pinot.set.instance.id.to.hostname=true
+
+controller.admin.access.control.principals=admin,user
+controller.admin.access.control.principals.user.password=secret
+controller.admin.access.control.principals.admin.password=admin


### PR DESCRIPTION
- Adds Basic auth to the `pinot-controller.conf` file
- Updates the pinot testContainer to use the b64 encoded token (`admin:admin`)