### PR TITLE
✨ support defining a dimension field as multi-valued

### DIFF
--- a/example/data-gen/block_header_schema.json
+++ b/example/data-gen/block_header_schema.json
@@ -16,6 +16,12 @@
       "name": "parent_hash",
       "dataType": "STRING",
       "notNull": false
+    },
+    {
+      "name": "tags",
+      "dataType": "STRING",
+      "notNull": false,
+      "singleValueField": false
     }
   ],
   "metricFieldSpecs": [

--- a/example/main.go
+++ b/example/main.go
@@ -58,6 +58,10 @@ func main() {
 
 }
 
+func boolPtr(b bool) *bool {
+	return &b
+}
+
 func demoTableFunctionality(client *pinot.PinotAPIClient) {
 
 	// Create Offline schema
@@ -67,31 +71,37 @@ func demoTableFunctionality(client *pinot.PinotAPIClient) {
 			{
 				Name:     "number",
 				DataType: "LONG",
-				NotNull:  false,
+				NotNull:  boolPtr(false),
 			},
 			{
 				Name:     "hash",
 				DataType: "STRING",
-				NotNull:  false,
+				NotNull:  boolPtr(false),
 			},
 			{
 				Name:     "parent_hash",
 				DataType: "STRING",
-				NotNull:  false,
+				NotNull:  boolPtr(false),
+			},
+			{
+				Name:             "tags",
+				DataType:         "STRING",
+				NotNull:          boolPtr(false),
+				SingleValueField: boolPtr(false),
 			},
 		},
 		MetricFieldSpecs: []model.FieldSpec{
 			{
 				Name:     "gas_used",
 				DataType: "LONG",
-				NotNull:  false,
+				NotNull:  boolPtr(false),
 			},
 		},
 		DateTimeFieldSpecs: []model.FieldSpec{
 			{
 				Name:        "timestamp",
 				DataType:    "LONG",
-				NotNull:     false,
+				NotNull:     boolPtr(false),
 				Format:      "1:MILLISECONDS:EPOCH",
 				Granularity: "1:MILLISECONDS",
 			},
@@ -284,31 +294,37 @@ func demoSchemaFromBytesFunctionality(client *pinot.PinotAPIClient) {
 			{
 				Name:     "number",
 				DataType: "LONG",
-				NotNull:  false,
+				NotNull:  boolPtr(false),
 			},
 			{
 				Name:     "hash",
 				DataType: "STRING",
-				NotNull:  false,
+				NotNull:  boolPtr(false),
 			},
 			{
 				Name:     "parent_hash",
 				DataType: "STRING",
-				NotNull:  false,
+				NotNull:  boolPtr(false),
+			},
+			{
+				Name:             "tags",
+				DataType:         "STRING",
+				NotNull:          boolPtr(false),
+				SingleValueField: boolPtr(false),
 			},
 		},
 		MetricFieldSpecs: []model.FieldSpec{
 			{
 				Name:     "gas_used",
 				DataType: "LONG",
-				NotNull:  false,
+				NotNull:  boolPtr(false),
 			},
 		},
 		DateTimeFieldSpecs: []model.FieldSpec{
 			{
 				Name:        "timestamp",
 				DataType:    "LONG",
-				NotNull:     false,
+				NotNull:     boolPtr(false),
 				Format:      "1:MILLISECONDS:EPOCH",
 				Granularity: "1:MILLISECONDS",
 			},
@@ -351,36 +367,42 @@ func demoSchemaFromBytesFunctionality(client *pinot.PinotAPIClient) {
 			{
 				Name:     "number",
 				DataType: "LONG",
-				NotNull:  false,
+				NotNull:  boolPtr(false),
 			},
 			{
 				Name:     "hash",
 				DataType: "STRING",
-				NotNull:  false,
+				NotNull:  boolPtr(false),
 			},
 			{
 				Name:     "parent_hash",
 				DataType: "STRING",
-				NotNull:  false,
+				NotNull:  boolPtr(false),
+			},
+			{
+				Name:             "tags",
+				DataType:         "STRING",
+				NotNull:          boolPtr(false),
+				SingleValueField: boolPtr(false),
 			},
 			{
 				Name:     "test",
 				DataType: "STRING",
-				NotNull:  false,
+				NotNull:  boolPtr(false),
 			},
 		},
 		MetricFieldSpecs: []model.FieldSpec{
 			{
 				Name:     "gas_used",
 				DataType: "LONG",
-				NotNull:  false,
+				NotNull:  boolPtr(false),
 			},
 		},
 		DateTimeFieldSpecs: []model.FieldSpec{
 			{
 				Name:        "timestamp",
 				DataType:    "LONG",
-				NotNull:     false,
+				NotNull:     boolPtr(false),
 				Format:      "1:MILLISECONDS:EPOCH",
 				Granularity: "1:MILLISECONDS",
 			},

--- a/go-pinot-api_test.go
+++ b/go-pinot-api_test.go
@@ -725,6 +725,10 @@ func getSchema() model.Schema {
 	return schema
 }
 
+func boolPtr(b bool) *bool {
+	return &b
+}
+
 // TestFetchData
 // func TestFetchData(t *testing.T) {
 
@@ -1167,6 +1171,11 @@ func TestCreateSchema(t *testing.T) {
 				Name:     "test",
 				DataType: "STRING",
 			},
+			{
+				Name:             "multiValuedField",
+				DataType:         "STRING",
+				SingleValueField: boolPtr(false),
+			},
 		},
 		MetricFieldSpecs: []model.FieldSpec{
 			{
@@ -1338,31 +1347,36 @@ func TestCreateTable(t *testing.T) {
 			{
 				Name:     "number",
 				DataType: "LONG",
-				NotNull:  false,
+				NotNull:  boolPtr(false),
 			},
 			{
 				Name:     "hash",
 				DataType: "STRING",
-				NotNull:  false,
+				NotNull:  boolPtr(false),
 			},
 			{
 				Name:     "parent_hash",
 				DataType: "STRING",
-				NotNull:  false,
+				NotNull:  boolPtr(false),
+			},
+			{
+				Name:             "tags",
+				DataType:         "STRING",
+				SingleValueField: boolPtr(false),
 			},
 		},
 		MetricFieldSpecs: []model.FieldSpec{
 			{
 				Name:     "gas_used",
 				DataType: "LONG",
-				NotNull:  false,
+				NotNull:  boolPtr(false),
 			},
 		},
 		DateTimeFieldSpecs: []model.FieldSpec{
 			{
 				Name:        "timestamp",
 				DataType:    "LONG",
-				NotNull:     false,
+				NotNull:     boolPtr(false),
 				Format:      "1:MILLISECONDS:EPOCH",
 				Granularity: "1:MILLISECONDS",
 			},

--- a/model/Schema.go
+++ b/model/Schema.go
@@ -3,11 +3,12 @@ package model
 import "encoding/json"
 
 type FieldSpec struct {
-	Name        string `json:"name"`
-	DataType    string `json:"dataType"`
-	NotNull     bool   `json:"notNull,omitempty"`
-	Format      string `json:"format,omitempty"`
-	Granularity string `json:"granularity,omitempty"`
+	Name             string `json:"name"`
+	DataType         string `json:"dataType"`
+	Format           string `json:"format,omitempty"`
+	Granularity      string `json:"granularity,omitempty"`
+	NotNull          *bool  `json:"notNull,omitempty"`
+	SingleValueField *bool  `json:"singleValueField,omitempty"`
 }
 
 type Schema struct {


### PR DESCRIPTION
Hey @azaurus1, I hope you're doing well!

As we discussed on https://github.com/azaurus1/terraform-provider-pinot/issues/56, this pull request is to add support for the `singleValueField` property. It requires a boolean to indicate if the field is single-valued or multi-valued.

The only issue I encountered was regarding how the `omitempty` option works. It states that the field should be excluded from the encoding if it has an empty value, defined as `false`, `0`, a `nil` pointer, a `nil` interface value, or any empty array, slice, map, or string.

When both `NotNull` and `SingleValueField` are set to false, they are omitted.

To address this issue, I've replaced it with a boolean pointer as this issue has been extensively debated and this seems to be the simpler workaround. Alternatively, we could use a different JSON serializer. There's also a proposal for golang to support this natively, which is almost ten years old. You can find it [here](https://github.com/golang/go/issues/11939).
