### PR TITLE
Change Table UpsertConfig MetadataTTL to float64

### DIFF
--- a/go-pinot-api_test.go
+++ b/go-pinot-api_test.go
@@ -403,7 +403,7 @@ func handleGetTableConfig(w http.ResponseWriter, r *http.Request) {
 				"dropOutOfOrderRecord":false,
 				"hashFunction":"NONE",
 				"defaultPartialUpsertStrategy":"OVERWRITE",
-				"metadataTTL":84600,
+				"metadataTTL":84600.0,
 				"deletedKeysTTL":0.0,
 				"enablePreload":false,
 				"enableSnapshot":true

--- a/model/Table.go
+++ b/model/Table.go
@@ -120,7 +120,7 @@ type UpsertConfig struct {
 	DefaultPartialUpsertStrategy string            `json:"defaultPartialUpsertStrategy,omitempty"`
 	ComparisonColumns            string            `json:"comparisonColumn,omitempty"`
 	DeleteRecordColumn           string            `json:"deleteRecordColumn,omitempty"`
-	MetadataTTL                  int64             `json:"metadataTTL,omitempty"`
+	MetadataTTL                  float64           `json:"metadataTTL,omitempty"`
 	DeletedKeysTTL               float64           `json:"deletedKeysTTL,omitempty"`
 	HashFunction                 string            `json:"hashFunction,omitempty"`
 	EnableSnapshot               *bool             `json:"enableSnapshot,omitempty"`


### PR DESCRIPTION
This pull request changes the table upsertConfig metadataTTL from int to float64 due to the error mentioned in the following issue:

https://github.com/azaurus1/go-pinot-api/issues/191