### PR TITLE
Add missing properties on forward index

### DIFF
--- a/model/Table.go
+++ b/model/Table.go
@@ -106,6 +106,8 @@ type FieldIndexForward struct {
 	CompressionCodec      string `json:"compressioncodec,omitempty"`
 	DeriveNumDocsPerChunk string `json:"derivenumdocsperchunk,omitempty"`
 	RawIndexWriterVersion string `json:"rawindexwriterversion,omitempty"`
+	TargetDocsPerChunk    string `json:"targetDocsPerChunk,omitempty"`
+	TargetMaxChunkSize    string `json:"targetMaxChunkSize,omitempty"`
 }
 
 type FieldIndexDictionary struct {


### PR DESCRIPTION
Hi again @azaurus1 
I would like to add some missing properties on forward indexes targetDocsPerChunk and targetMaxChunkSize.
I will also implement it in the terraform-provider-pinot project.