### PR TITLE
Include properties to Dedup config

### DIFF
--- a/model/Table.go
+++ b/model/Table.go
@@ -213,8 +213,10 @@ type UpsertConfig struct {
 }
 
 type DedupConfig struct {
-	DedupEnabled bool   `json:"dedupEnabled"`
-	HashFunction string `json:"hashFunction"`
+	DedupEnabled    bool    `json:"dedupEnabled"`
+	HashFunction    string  `json:"hashFunction"`
+	DedupTimeColumn string  `json:"dedupTimeColumn"`
+	MetadataTTL     float64 `json:"metadataTTL"`
 }
 
 type TransformConfig struct {


### PR DESCRIPTION
This PR adds `dedupTimeColumn` and `metadataTTL` to the Dedup Config struct to configure the realtime table with these values set.